### PR TITLE
ci: add PyPI publish workflow with bump-and-tag pattern

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,124 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type'
+        required: true
+        type: choice
+        options: [patch, minor, major]
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  bump_and_tag:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.semver.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get previous tag
+        id: prev_tag
+        uses: WyriHaximus/github-action-get-previous-tag@v2
+
+      - name: Compute next versions
+        id: next_semver
+        uses: WyriHaximus/github-action-next-semvers@v1
+        with:
+          version: ${{ steps.prev_tag.outputs.tag }}
+
+      - name: Select version
+        id: semver
+        run: |
+          case "${{ inputs.release_type }}" in
+            patch) echo "version=${{ steps.next_semver.outputs.patch }}" >> "$GITHUB_OUTPUT" ;;
+            minor) echo "version=${{ steps.next_semver.outputs.minor }}" >> "$GITHUB_OUTPUT" ;;
+            major) echo "version=${{ steps.next_semver.outputs.major }}" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Update version in pyproject.toml
+        run: |
+          sed -i "s/^version = \".*\"/version = \"${{ steps.semver.outputs.version }}\"/" pyproject.toml
+          grep '^version' pyproject.toml
+
+      - name: Commit version bump and tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml
+          git commit -m "chore(release): bump version to ${{ steps.semver.outputs.version }} [skip ci]" || echo "Nothing to commit"
+          git tag "v${{ steps.semver.outputs.version }}"
+          git push origin HEAD --tags
+
+  publish:
+    if: |
+      always() &&
+      (github.event_name == 'push' ||
+       (github.event_name == 'workflow_dispatch' && needs.bump_and_tag.result == 'success'))
+    needs: [bump_and_tag]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Resolve version
+        id: resolve
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${{ needs.bump_and_tag.outputs.version }}" >> "$GITHUB_OUTPUT"
+            echo "tag=v${{ needs.bump_and_tag.outputs.version }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.resolve.outputs.tag }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv pip install -e ".[dev]" --system
+
+      - name: Run tests
+        run: uv run pytest --cov=flutter_setup --cov-fail-under=75
+
+      - name: Build wheel and sdist
+        run: uv build
+
+      - name: Smoke-test installed CLI
+        run: |
+          uv pip install dist/*.whl --system
+          flutter-setup --help
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.resolve.outputs.tag }}
+          name: flutter-setup ${{ steps.resolve.outputs.tag }}
+          generate_release_notes: true
+          files: dist/*


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish.yml` to publish `flutter-setup` to PyPI on every release
- Uses the bump-and-tag pattern: `workflow_dispatch` with `patch`/`minor`/`major` input bumps `pyproject.toml`, commits, tags, and triggers publish
- Also supports direct `v*` tag pushes to skip straight to the publish job
- Publishes via PyPI trusted publishing (OIDC — no stored API token needed)
- Attaches wheel + sdist to a GitHub Release alongside the PyPI publish

## Test plan

- [ ] Set up PyPI trusted publishing for `markcallen/flutter-setup`, workflow `publish.yml`
- [ ] Trigger the workflow via Actions → Publish → Run workflow → choose `patch`
- [ ] Verify `pyproject.toml` version is bumped and a `v*` tag is created
- [ ] Verify the package appears on PyPI and the GitHub Release has `dist/` artifacts attached
- [ ] Confirm `flutter-setup --help` smoke test passes in the publish job

🤖 Generated with [Claude Code](https://claude.com/claude-code)