### PR TITLE
fix: address FS-001 through FS-011 scaffold quality issues

### DIFF
--- a/flutter_setup/bootstrap.py
+++ b/flutter_setup/bootstrap.py
@@ -506,7 +506,39 @@ Future<void> main() async {{
 }}
 """)
 
+        self._create_assets_scaffold()
+
         console.print("  ✅ Clean Architecture scaffold created")
+
+    def _create_assets_scaffold(self) -> None:
+        """Create assets/ directories and declare them in pubspec.yaml.
+
+        Uses .gitkeep sentinels so the empty directories are tracked in git.
+        """
+        assets_root = self.config.project_path / "assets"
+        asset_dirs = [
+            assets_root / "images",
+            assets_root / "fonts",
+        ]
+        for asset_dir in asset_dirs:
+            asset_dir.mkdir(parents=True, exist_ok=True)
+            (asset_dir / ".gitkeep").touch()
+
+        pubspec_path = self.config.project_path / "pubspec.yaml"
+        if not pubspec_path.exists():
+            return
+        try:
+            with open(pubspec_path, "r") as f:
+                pubspec = yaml.safe_load(f) or {}
+            flutter_section = pubspec.setdefault("flutter", {})
+            assets = flutter_section.setdefault("assets", [])
+            if "assets/images/" not in assets:
+                assets.append("assets/images/")
+            with open(pubspec_path, "w") as f:
+                yaml.dump(pubspec, f, default_flow_style=False, sort_keys=False)
+            console.print("  ✅ Assets directories created")
+        except Exception as e:
+            console.print(f"  ⚠️  Failed to declare assets in pubspec.yaml: {e}")
 
     def _create_sqlite_scaffold(self) -> None:
         """Create a Drift/SQLite starter database scaffold."""

--- a/flutter_setup/bootstrap.py
+++ b/flutter_setup/bootstrap.py
@@ -170,7 +170,7 @@ check-flutter-version:
 
         generate_target = ""
         codegen_dep = ""
-        if self.config.database == "sqlite":
+        if self.config.database == "sqlite" or self.config.architecture == "clean":
             generate_target = f"""
 generate:{version_dep}
 \tdart run build_runner build --delete-conflicting-outputs
@@ -434,6 +434,7 @@ final router = GoRouter(
 """
         )
 
+        safe_title = self.config.project_name.replace("'", "\\'")
         (src_dir / "app" / "app.dart").write_text(
             f"""import 'package:flutter/material.dart';
 
@@ -445,7 +446,7 @@ class App extends StatelessWidget {{
   @override
   Widget build(BuildContext context) {{
     return MaterialApp.router(
-      title: '{self.config.project_name}',
+      title: '{safe_title}',
       theme: ThemeData(useMaterial3: true),
       routerConfig: router,
     );
@@ -763,7 +764,12 @@ class FirebaseNotificationsService {
         dependencies = ["flutter_lints"]
 
         if self.config.architecture == "clean":
-            dependencies.extend(["riverpod_generator", "freezed", "json_serializable"])
+            # build_runner is required to run riverpod_generator, freezed, and
+            # json_serializable — add it here so clean-arch projects without
+            # sqlite still get code generation support.
+            dependencies.extend(
+                ["riverpod_generator", "freezed", "json_serializable", "build_runner"]
+            )
 
         if self.config.database == "sqlite":
             dependencies.extend(["drift_dev", "build_runner"])
@@ -773,14 +779,23 @@ class FirebaseNotificationsService {
 
         return dependencies
 
+    _GENERIC_PUBSPEC_DESCRIPTION = "A new Flutter project."
+
     def _update_pubspec_description(self) -> None:
-        """Replace the generic 'A new Flutter project.' description in pubspec.yaml."""
+        """Replace the generic flutter-create description in pubspec.yaml.
+
+        Only overwrites the known placeholder left by `flutter create` so that
+        re-running bootstrap does not clobber a description the developer has
+        already customised.
+        """
         pubspec_path = self.config.project_path / "pubspec.yaml"
         if not pubspec_path.exists():
             return
         try:
             with open(pubspec_path, "r") as f:
                 pubspec = yaml.safe_load(f) or {}
+            if pubspec.get("description") != self._GENERIC_PUBSPEC_DESCRIPTION:
+                return
             pubspec["description"] = (
                 f"A {self.config.project_name} Flutter application."
             )
@@ -1113,7 +1128,7 @@ project before using the generated Firebase services.
         compile on first checkout.
         """
         try:
-            subprocess.run(
+            result = subprocess.run(
                 [
                     str(self.flutter_root / "bin" / "dart"),
                     "run",
@@ -1125,7 +1140,14 @@ project before using the generated Firebase services.
                 check=False,
                 capture_output=True,
             )
-            console.print("  ✅ Code generation completed (build_runner)")
+            if result.returncode == 0:
+                console.print("  ✅ Code generation completed (build_runner)")
+            else:
+                stderr = result.stderr.decode(errors="replace") if result.stderr else ""
+                console.print(
+                    f"  ⚠️  build_runner exited with code {result.returncode}"
+                    + (f": {stderr.strip()}" if stderr.strip() else "")
+                )
         except Exception as e:
             console.print(f"  ⚠️  build_runner warning: {e}")
 

--- a/flutter_setup/bootstrap.py
+++ b/flutter_setup/bootstrap.py
@@ -69,6 +69,11 @@ class ProjectBootstrap:
         # flutter version pin) are resolved before the user's first make target.
         self._run_pub_get()
 
+        # Run build_runner for projects that require code generation (Drift,
+        # Riverpod, Freezed) so the project compiles immediately after setup.
+        if self.config.database == "sqlite" or self.config.architecture == "clean":
+            self._run_build_runner()
+
         # Create README
         self._create_readme()
 
@@ -958,6 +963,17 @@ API_URL=https://api.example.com
         else:
             run_cmd = "flutter run"
 
+        codegen_section = ""
+        if self.config.database == "sqlite" or self.config.architecture == "clean":
+            codegen_section = """
+## Code generation
+This project uses `build_runner` for code generation (Drift, Riverpod, Freezed).
+Generation runs automatically during setup. To re-run manually:
+```bash
+make generate
+```
+"""
+
         readme_content = f"""# {self.config.project_name}
 
 Flutter app scaffolded for Cursor.
@@ -967,7 +983,7 @@ Flutter app scaffolded for Cursor.
 flutter pub get
 {run_cmd}
 ```
-
+{codegen_section}
 ## Testing
 ```bash
 make test           # unit + widget tests
@@ -1020,6 +1036,30 @@ project before using the generated Firebase services.
             console.print("  ✅ flutter pub get completed")
         except Exception as e:
             console.print(f"  ⚠️  flutter pub get warning: {e}")
+
+    def _run_build_runner(self) -> None:
+        """Run build_runner to generate code for Drift, Riverpod, and Freezed.
+
+        Projects using sqlite or clean architecture include code-generated files
+        (*.g.dart, *.freezed.dart). Without this step the project will not
+        compile on first checkout.
+        """
+        try:
+            subprocess.run(
+                [
+                    str(self.flutter_root / "bin" / "dart"),
+                    "run",
+                    "build_runner",
+                    "build",
+                    "--delete-conflicting-outputs",
+                ],
+                cwd=self.config.project_path,
+                check=False,
+                capture_output=True,
+            )
+            console.print("  ✅ Code generation completed (build_runner)")
+        except Exception as e:
+            console.print(f"  ⚠️  build_runner warning: {e}")
 
     def _format_code(self) -> None:
         """Format the generated code."""

--- a/flutter_setup/bootstrap.py
+++ b/flutter_setup/bootstrap.py
@@ -56,6 +56,9 @@ class ProjectBootstrap:
         # Add dependencies
         self._add_dependencies()
 
+        # Update pubspec description (flutter create leaves a generic placeholder)
+        self._update_pubspec_description()
+
         # Create environment support (.env file + gitignore entry; NOT added to assets)
         self._create_environment_support()
 
@@ -721,6 +724,23 @@ class FirebaseNotificationsService {
             dependencies.append("mocktail")
 
         return dependencies
+
+    def _update_pubspec_description(self) -> None:
+        """Replace the generic 'A new Flutter project.' description in pubspec.yaml."""
+        pubspec_path = self.config.project_path / "pubspec.yaml"
+        if not pubspec_path.exists():
+            return
+        try:
+            with open(pubspec_path, "r") as f:
+                pubspec = yaml.safe_load(f) or {}
+            pubspec["description"] = (
+                f"A {self.config.project_name} Flutter application."
+            )
+            with open(pubspec_path, "w") as f:
+                yaml.dump(pubspec, f, default_flow_style=False, sort_keys=False)
+            console.print("  ✅ pubspec description updated")
+        except Exception as e:
+            console.print(f"  ⚠️  Failed to update pubspec description: {e}")
 
     def _pin_flutter_sdk_version(self, version: str) -> None:
         """Set the flutter SDK constraint in pubspec.yaml to >= the given version."""

--- a/flutter_setup/bootstrap.py
+++ b/flutter_setup/bootstrap.py
@@ -670,7 +670,18 @@ class FirebaseNotificationsService {
         dependencies = ["flutter_dotenv"]
 
         if self.config.architecture == "clean":
-            dependencies.append("flutter_riverpod")
+            dependencies.extend(
+                [
+                    "flutter_riverpod",
+                    "riverpod_annotation",
+                    "go_router",
+                    "freezed_annotation",
+                    "json_annotation",
+                    "collection",
+                    "intl",
+                    "uuid",
+                ]
+            )
 
         if self.config.database == "sqlite":
             dependencies.extend(
@@ -694,6 +705,9 @@ class FirebaseNotificationsService {
     def _dev_dependencies(self) -> list[str]:
         """Return dev dependencies required by selected scaffolds."""
         dependencies = ["flutter_lints"]
+
+        if self.config.architecture == "clean":
+            dependencies.extend(["riverpod_generator", "freezed", "json_serializable"])
 
         if self.config.database == "sqlite":
             dependencies.extend(["drift_dev", "build_runner"])

--- a/flutter_setup/bootstrap.py
+++ b/flutter_setup/bootstrap.py
@@ -766,7 +766,7 @@ class FirebaseNotificationsService {
 
         flutter pub add can silently fail in some environments; this guarantees
         the entry is present regardless. The version constraint is derived from
-        the runtime drift package so the code-generator major version always matches.
+        the runtime drift package so the code-generator version always matches.
         """
         import re
 
@@ -778,11 +778,13 @@ class FirebaseNotificationsService {
                 pubspec = yaml.safe_load(f) or {}
             dev_deps = pubspec.setdefault("dev_dependencies", {})
             if "drift_dev" not in dev_deps:
-                # Pin drift_dev to the same major version as the runtime drift
-                # package: a major-version mismatch causes incompatible codegen.
+                # Pin drift_dev to the same full version as the runtime drift
+                # package: drift_dev must match drift's minor version since each
+                # minor release may add new codegen features the old generator
+                # doesn't know about. e.g. drift: ^2.31.0 -> drift_dev: ^2.31.0
                 drift_constraint = pubspec.get("dependencies", {}).get("drift", "")
-                match = re.match(r"[\^~]?(\d+)", str(drift_constraint))
-                version = f"^{match.group(1)}.0.0" if match else "any"
+                match = re.match(r"[\^~]?(\d+\.\d+\.\d+)", str(drift_constraint))
+                version = f"^{match.group(1)}" if match else "any"
                 dev_deps["drift_dev"] = version
                 with open(pubspec_path, "w") as f:
                     yaml.dump(pubspec, f, default_flow_style=False, sort_keys=False)

--- a/flutter_setup/bootstrap.py
+++ b/flutter_setup/bootstrap.py
@@ -418,20 +418,36 @@ linter:
         for directory in directories:
             directory.mkdir(parents=True, exist_ok=True)
 
+        (src_dir / "app" / "router.dart").write_text(
+            """import 'package:go_router/go_router.dart';
+
+import '../features/home/presentation/home_screen.dart';
+
+final router = GoRouter(
+  routes: [
+    GoRoute(
+      path: '/',
+      builder: (context, state) => const HomeScreen(),
+    ),
+  ],
+);
+"""
+        )
+
         (src_dir / "app" / "app.dart").write_text(
             f"""import 'package:flutter/material.dart';
 
-import '../features/home/presentation/home_screen.dart';
+import 'router.dart';
 
 class App extends StatelessWidget {{
   const App({{super.key}});
 
   @override
   Widget build(BuildContext context) {{
-    return MaterialApp(
+    return MaterialApp.router(
       title: '{self.config.project_name}',
       theme: ThemeData(useMaterial3: true),
-      home: const HomeScreen(),
+      routerConfig: router,
     );
   }}
 }}

--- a/flutter_setup/bootstrap.py
+++ b/flutter_setup/bootstrap.py
@@ -416,22 +416,22 @@ linter:
             directory.mkdir(parents=True, exist_ok=True)
 
         (src_dir / "app" / "app.dart").write_text(
-            """import 'package:flutter/material.dart';
+            f"""import 'package:flutter/material.dart';
 
 import '../features/home/presentation/home_screen.dart';
 
-class App extends StatelessWidget {
-  const App({super.key});
+class App extends StatelessWidget {{
+  const App({{super.key}});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context) {{
     return MaterialApp(
-      title: 'Flutter App',
+      title: '{self.config.project_name}',
       theme: ThemeData(useMaterial3: true),
       home: const HomeScreen(),
     );
-  }
-}
+  }}
+}}
 """
         )
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -968,6 +968,23 @@ class TestProjectBootstrap:
             assert "ConsumerWidget" not in app_content
             assert "WidgetRef" not in app_content
 
+    def test_clean_architecture_app_title_uses_project_name(
+        self, config: Config
+    ) -> None:
+        """Test that app.dart uses the project name as the MaterialApp title."""
+        config.architecture = "clean"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.output_dir = Path(tmpdir)
+            (config.project_path / "lib").mkdir(parents=True, exist_ok=True)
+            (config.project_path / "lib" / "main.dart").write_text("void main() {}")
+            bootstrap = ProjectBootstrap(config)
+            bootstrap._create_architecture_scaffold()
+            app_content = (
+                config.project_path / "lib" / "src" / "app" / "app.dart"
+            ).read_text()
+            assert f"title: '{config.project_name}'" in app_content
+            assert "Flutter App" not in app_content
+
     def test_clean_architecture_home_screen_uses_stateless_widget(
         self, config: Config
     ) -> None:

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1007,7 +1007,39 @@ class TestProjectBootstrap:
             ).read_text()
             assert "StatelessWidget" in screen_content
             assert "ConsumerWidget" not in screen_content
-            assert "WidgetRef" not in screen_content
+
+    def test_clean_architecture_uses_go_router(self, config: Config) -> None:
+        """Test that app.dart uses MaterialApp.router with GoRouter."""
+        config.architecture = "clean"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.output_dir = Path(tmpdir)
+            (config.project_path / "lib").mkdir(parents=True, exist_ok=True)
+            (config.project_path / "lib" / "main.dart").write_text("void main() {}")
+            bootstrap = ProjectBootstrap(config)
+            bootstrap._create_architecture_scaffold()
+            app_content = (
+                config.project_path / "lib" / "src" / "app" / "app.dart"
+            ).read_text()
+            assert "MaterialApp.router" in app_content
+            assert "routerConfig: router" in app_content
+            assert "MaterialApp(" not in app_content
+
+    def test_clean_architecture_creates_router_file(self, config: Config) -> None:
+        """Test that router.dart is generated with a GoRouter and home route."""
+        config.architecture = "clean"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.output_dir = Path(tmpdir)
+            (config.project_path / "lib").mkdir(parents=True, exist_ok=True)
+            (config.project_path / "lib" / "main.dart").write_text("void main() {}")
+            bootstrap = ProjectBootstrap(config)
+            bootstrap._create_architecture_scaffold()
+            router_path = config.project_path / "lib" / "src" / "app" / "router.dart"
+            assert router_path.exists()
+            router_content = router_path.read_text()
+            assert "GoRouter" in router_content
+            assert "HomeScreen" in router_content
+            assert "path: '/'" in router_content
+            assert "WidgetRef" not in router_content
 
     def test_create_sqlite_scaffold(self, config: Config) -> None:
         """Test creating Drift SQLite scaffold."""

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -373,7 +373,7 @@ class TestProjectBootstrap:
             assert "UnimplementedError" in content
 
     def test_add_drift_dev_to_pubspec(self, config: Config) -> None:
-        """Test that drift_dev is written with a version-pinned constraint."""
+        """Test that drift_dev is written with a full-version-pinned constraint."""
         with tempfile.TemporaryDirectory() as tmpdir:
             config.output_dir = Path(tmpdir)
             config.database = "sqlite"
@@ -387,9 +387,27 @@ class TestProjectBootstrap:
             bootstrap._add_drift_dev_to_pubspec()
             content = yaml.safe_load(pubspec_path.read_text())
             assert "drift_dev" in content["dev_dependencies"]
-            # Must not use unconstrained 'any' — major version must match runtime drift
-            assert content["dev_dependencies"]["drift_dev"] != "any"
-            assert content["dev_dependencies"]["drift_dev"].startswith("^2")
+            # drift_dev must match drift's full version, not just the major.
+            # drift: ^2.31.0 -> drift_dev: ^2.31.0 (not ^2.0.0)
+            assert content["dev_dependencies"]["drift_dev"] == "^2.31.0"
+
+    def test_add_drift_dev_to_pubspec_major_only_falls_back(
+        self, config: Config
+    ) -> None:
+        """Test that drift_dev falls back to 'any' when drift constraint has no full version."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.output_dir = Path(tmpdir)
+            config.database = "sqlite"
+            config.project_path.mkdir(parents=True, exist_ok=True)
+            pubspec_path = config.project_path / "pubspec.yaml"
+            pubspec_path.write_text(
+                "name: test\ndependencies:\n  drift: any\n"
+                "dev_dependencies:\n  build_runner: ^2.9.0\n"
+            )
+            bootstrap = ProjectBootstrap(config)
+            bootstrap._add_drift_dev_to_pubspec()
+            content = yaml.safe_load(pubspec_path.read_text())
+            assert content["dev_dependencies"]["drift_dev"] == "any"
 
     def test_add_drift_dev_to_pubspec_skips_if_already_present(
         self, config: Config

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -470,6 +470,101 @@ class TestProjectBootstrap:
             mock_run.side_effect = Exception("Failed")
             bootstrap._run_pub_get()  # Should not raise, just warn
 
+    def test_run_build_runner(
+        self, bootstrap: ProjectBootstrap, config: Config
+    ) -> None:
+        """Test that _run_build_runner calls dart run build_runner build."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = Mock(returncode=0)
+            bootstrap._run_build_runner()
+            mock_run.assert_called_once()
+            args = mock_run.call_args[0][0]
+            assert "build_runner" in args
+            assert "build" in args
+            assert "--delete-conflicting-outputs" in args
+            assert mock_run.call_args[1]["cwd"] == config.project_path
+
+    def test_run_build_runner_failure(
+        self, bootstrap: ProjectBootstrap, config: Config
+    ) -> None:
+        """Test that _run_build_runner handles errors gracefully."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = Exception("Failed")
+            bootstrap._run_build_runner()  # Should not raise, just warn
+
+    def test_bootstrap_project_runs_build_runner_for_sqlite(
+        self, config: Config
+    ) -> None:
+        """Test that bootstrap_project calls _run_build_runner for sqlite projects."""
+        config.database = "sqlite"
+        bootstrap = ProjectBootstrap(config)
+        with (
+            patch.object(bootstrap, "_create_vscode_config"),
+            patch.object(bootstrap, "_create_makefile"),
+            patch.object(bootstrap, "_create_test_structure"),
+            patch.object(bootstrap, "_create_analysis_options"),
+            patch.object(bootstrap, "_create_architecture_scaffold"),
+            patch.object(bootstrap, "_create_cicd"),
+            patch.object(bootstrap, "_add_dependencies"),
+            patch.object(bootstrap, "_create_environment_support"),
+            patch.object(bootstrap, "_run_pub_get"),
+            patch.object(bootstrap, "_run_build_runner") as mock_br,
+            patch.object(bootstrap, "_create_readme"),
+            patch.object(bootstrap, "_format_code"),
+            patch.object(bootstrap, "_detect_flutter_version", return_value=None),
+        ):
+            bootstrap.bootstrap_project()
+            mock_br.assert_called_once()
+
+    def test_bootstrap_project_runs_build_runner_for_clean_arch(
+        self, config: Config
+    ) -> None:
+        """Test that bootstrap_project calls _run_build_runner for clean architecture."""
+        config.architecture = "clean"
+        bootstrap = ProjectBootstrap(config)
+        with (
+            patch.object(bootstrap, "_create_vscode_config"),
+            patch.object(bootstrap, "_create_makefile"),
+            patch.object(bootstrap, "_create_test_structure"),
+            patch.object(bootstrap, "_create_analysis_options"),
+            patch.object(bootstrap, "_create_architecture_scaffold"),
+            patch.object(bootstrap, "_create_cicd"),
+            patch.object(bootstrap, "_add_dependencies"),
+            patch.object(bootstrap, "_create_environment_support"),
+            patch.object(bootstrap, "_run_pub_get"),
+            patch.object(bootstrap, "_run_build_runner") as mock_br,
+            patch.object(bootstrap, "_create_readme"),
+            patch.object(bootstrap, "_format_code"),
+            patch.object(bootstrap, "_detect_flutter_version", return_value=None),
+        ):
+            bootstrap.bootstrap_project()
+            mock_br.assert_called_once()
+
+    def test_bootstrap_project_skips_build_runner_for_basic_no_db(
+        self, config: Config
+    ) -> None:
+        """Test that build_runner is not invoked for basic arch with no database."""
+        config.architecture = "basic"
+        config.database = "none"
+        bootstrap = ProjectBootstrap(config)
+        with (
+            patch.object(bootstrap, "_create_vscode_config"),
+            patch.object(bootstrap, "_create_makefile"),
+            patch.object(bootstrap, "_create_test_structure"),
+            patch.object(bootstrap, "_create_analysis_options"),
+            patch.object(bootstrap, "_create_architecture_scaffold"),
+            patch.object(bootstrap, "_create_cicd"),
+            patch.object(bootstrap, "_add_dependencies"),
+            patch.object(bootstrap, "_create_environment_support"),
+            patch.object(bootstrap, "_run_pub_get"),
+            patch.object(bootstrap, "_run_build_runner") as mock_br,
+            patch.object(bootstrap, "_create_readme"),
+            patch.object(bootstrap, "_format_code"),
+            patch.object(bootstrap, "_detect_flutter_version", return_value=None),
+        ):
+            bootstrap.bootstrap_project()
+            mock_br.assert_not_called()
+
     def test_add_integration_test_sdk_dependency_no_pubspec(
         self, bootstrap: ProjectBootstrap, config: Config
     ) -> None:
@@ -802,6 +897,36 @@ class TestProjectBootstrap:
             assert "make integration" in content
             assert "make analyze" in content
             assert ".env" in content
+            # basic arch + no db should NOT include the codegen section
+            assert "make generate" not in content
+
+    def test_create_readme_includes_codegen_section_for_sqlite(
+        self, config: Config
+    ) -> None:
+        """Test that the README includes the code generation section for sqlite projects."""
+        config.database = "sqlite"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.output_dir = Path(tmpdir)
+            config.project_path.mkdir(parents=True, exist_ok=True)
+            bootstrap = ProjectBootstrap(config)
+            bootstrap._create_readme()
+            content = (config.project_path / "README.md").read_text()
+            assert "make generate" in content
+            assert "build_runner" in content
+
+    def test_create_readme_includes_codegen_section_for_clean_arch(
+        self, config: Config
+    ) -> None:
+        """Test that the README includes the code generation section for clean arch."""
+        config.architecture = "clean"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.output_dir = Path(tmpdir)
+            config.project_path.mkdir(parents=True, exist_ok=True)
+            bootstrap = ProjectBootstrap(config)
+            bootstrap._create_readme()
+            content = (config.project_path / "README.md").read_text()
+            assert "make generate" in content
+            assert "build_runner" in content
 
     def test_create_clean_architecture_scaffold(self, config: Config) -> None:
         """Test creating Clean Architecture scaffold."""

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1151,6 +1151,31 @@ class TestProjectBootstrap:
         with patch("subprocess.run", side_effect=OSError("not found")):
             assert bootstrap._detect_flutter_version() is None
 
+    # --- _update_pubspec_description ---
+
+    def test_update_pubspec_description(self, config: Config) -> None:
+        """Test that pubspec description is updated to include the project name."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.output_dir = Path(tmpdir)
+            config.project_path.mkdir(parents=True, exist_ok=True)
+            pubspec_path = config.project_path / "pubspec.yaml"
+            pubspec_path.write_text(
+                "name: testapp\ndescription: A new Flutter project.\n"
+            )
+            bootstrap = ProjectBootstrap(config)
+            bootstrap._update_pubspec_description()
+            pubspec = yaml.safe_load(pubspec_path.read_text())
+            assert config.project_name in pubspec["description"]
+            assert "A new Flutter project." != pubspec["description"]
+
+    def test_update_pubspec_description_no_pubspec(self, config: Config) -> None:
+        """Test that missing pubspec.yaml is handled gracefully."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.output_dir = Path(tmpdir)
+            config.project_path.mkdir(parents=True, exist_ok=True)
+            bootstrap = ProjectBootstrap(config)
+            bootstrap._update_pubspec_description()  # should not raise
+
     # --- _pin_flutter_sdk_version ---
 
     def test_pin_flutter_sdk_version_writes_constraint(

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1041,6 +1041,53 @@ class TestProjectBootstrap:
             assert "path: '/'" in router_content
             assert "WidgetRef" not in router_content
 
+    def test_create_assets_scaffold_creates_directories(self, config: Config) -> None:
+        """Test that assets directories are created with .gitkeep sentinels."""
+        config.architecture = "clean"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.output_dir = Path(tmpdir)
+            (config.project_path / "lib").mkdir(parents=True, exist_ok=True)
+            (config.project_path / "lib" / "main.dart").write_text("void main() {}")
+            bootstrap = ProjectBootstrap(config)
+            bootstrap._create_architecture_scaffold()
+            assert (config.project_path / "assets" / "images").is_dir()
+            assert (config.project_path / "assets" / "fonts").is_dir()
+            assert (config.project_path / "assets" / "images" / ".gitkeep").exists()
+            assert (config.project_path / "assets" / "fonts" / ".gitkeep").exists()
+
+    def test_create_assets_scaffold_declares_in_pubspec(self, config: Config) -> None:
+        """Test that assets/images/ is declared in pubspec.yaml flutter.assets."""
+        config.architecture = "clean"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.output_dir = Path(tmpdir)
+            (config.project_path / "lib").mkdir(parents=True, exist_ok=True)
+            (config.project_path / "lib" / "main.dart").write_text("void main() {}")
+            pubspec_path = config.project_path / "pubspec.yaml"
+            pubspec_path.write_text(
+                "name: test\nflutter:\n  uses-material-design: true\n"
+            )
+            bootstrap = ProjectBootstrap(config)
+            bootstrap._create_architecture_scaffold()
+            pubspec = yaml.safe_load(pubspec_path.read_text())
+            assert "assets/images/" in pubspec["flutter"]["assets"]
+
+    def test_create_assets_scaffold_idempotent(self, config: Config) -> None:
+        """Test that calling _create_assets_scaffold twice does not duplicate entries."""
+        config.architecture = "clean"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.output_dir = Path(tmpdir)
+            (config.project_path / "lib").mkdir(parents=True, exist_ok=True)
+            (config.project_path / "lib" / "main.dart").write_text("void main() {}")
+            pubspec_path = config.project_path / "pubspec.yaml"
+            pubspec_path.write_text(
+                "name: test\nflutter:\n  uses-material-design: true\n"
+            )
+            bootstrap = ProjectBootstrap(config)
+            bootstrap._create_assets_scaffold()
+            bootstrap._create_assets_scaffold()
+            pubspec = yaml.safe_load(pubspec_path.read_text())
+            assert pubspec["flutter"]["assets"].count("assets/images/") == 1
+
     def test_create_sqlite_scaffold(self, config: Config) -> None:
         """Test creating Drift SQLite scaffold."""
         config.database = "sqlite"

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -95,6 +95,20 @@ class TestProjectBootstrap:
             assert "run-chrome:" not in content
             assert "analyze:" in content
 
+    def test_create_makefile_generates_target_for_clean_arch(
+        self, config: Config
+    ) -> None:
+        """Test that make generate target is created for clean architecture projects."""
+        config.architecture = "clean"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.output_dir = Path(tmpdir)
+            config.project_path.mkdir(parents=True, exist_ok=True)
+            bootstrap = ProjectBootstrap(config)
+            bootstrap._create_makefile()
+            content = (config.project_path / "Makefile").read_text()
+            assert "generate:" in content
+            assert "build_runner" in content
+
     def test_check_flutter_version_target_verifies_version(
         self, config: Config
     ) -> None:
@@ -484,10 +498,18 @@ class TestProjectBootstrap:
             assert "--delete-conflicting-outputs" in args
             assert mock_run.call_args[1]["cwd"] == config.project_path
 
+    def test_run_build_runner_nonzero_exit_warns(
+        self, bootstrap: ProjectBootstrap, config: Config
+    ) -> None:
+        """Test that _run_build_runner warns when build_runner exits non-zero."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = Mock(returncode=1, stderr=b"some error")
+            bootstrap._run_build_runner()  # Should not raise, just warn
+
     def test_run_build_runner_failure(
         self, bootstrap: ProjectBootstrap, config: Config
     ) -> None:
-        """Test that _run_build_runner handles errors gracefully."""
+        """Test that _run_build_runner handles subprocess exceptions gracefully."""
         with patch("subprocess.run") as mock_run:
             mock_run.side_effect = Exception("Failed")
             bootstrap._run_build_runner()  # Should not raise, just warn
@@ -985,6 +1007,24 @@ class TestProjectBootstrap:
             assert f"title: '{config.project_name}'" in app_content
             assert "Flutter App" not in app_content
 
+    def test_clean_architecture_app_title_escapes_apostrophe(
+        self, config: Config
+    ) -> None:
+        """Test that apostrophes in the project name are escaped in app.dart."""
+        config.project_name = "Sam's App"
+        config.architecture = "clean"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.output_dir = Path(tmpdir)
+            (config.project_path / "lib").mkdir(parents=True, exist_ok=True)
+            (config.project_path / "lib" / "main.dart").write_text("void main() {}")
+            bootstrap = ProjectBootstrap(config)
+            bootstrap._create_architecture_scaffold()
+            app_content = (
+                config.project_path / "lib" / "src" / "app" / "app.dart"
+            ).read_text()
+            # The apostrophe must be escaped so the Dart string is valid
+            assert r"Sam\'s App" in app_content
+
     def test_clean_architecture_home_screen_uses_stateless_widget(
         self, config: Config
     ) -> None:
@@ -1193,6 +1233,16 @@ class TestProjectBootstrap:
         assert "freezed" not in dev_dependencies
         assert "json_serializable" not in dev_dependencies
 
+    def test_clean_arch_without_sqlite_includes_build_runner(
+        self, config: Config
+    ) -> None:
+        """build_runner must be in dev deps for clean arch even without sqlite."""
+        config.architecture = "clean"
+        config.database = "none"
+        bootstrap = ProjectBootstrap(config)
+        dev_deps = bootstrap._dev_dependencies()
+        assert "build_runner" in dev_deps
+
     # --- _detect_flutter_version ---
 
     def test_detect_flutter_version_from_stdout(
@@ -1254,6 +1304,21 @@ class TestProjectBootstrap:
             config.project_path.mkdir(parents=True, exist_ok=True)
             bootstrap = ProjectBootstrap(config)
             bootstrap._update_pubspec_description()  # should not raise
+
+    def test_update_pubspec_description_does_not_overwrite_custom(
+        self, config: Config
+    ) -> None:
+        """Test that a developer-customised description is not overwritten."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.output_dir = Path(tmpdir)
+            config.project_path.mkdir(parents=True, exist_ok=True)
+            pubspec_path = config.project_path / "pubspec.yaml"
+            custom = "My custom project description."
+            pubspec_path.write_text(f"name: testapp\ndescription: {custom}\n")
+            bootstrap = ProjectBootstrap(config)
+            bootstrap._update_pubspec_description()
+            pubspec = yaml.safe_load(pubspec_path.read_text())
+            assert pubspec["description"] == custom
 
     # --- _pin_flutter_sdk_version ---
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -932,15 +932,45 @@ class TestProjectBootstrap:
         runtime_dependencies = bootstrap._runtime_dependencies()
         dev_dependencies = bootstrap._dev_dependencies()
 
+        # clean arch runtime packages
         assert "flutter_riverpod" in runtime_dependencies
+        assert "riverpod_annotation" in runtime_dependencies
+        assert "go_router" in runtime_dependencies
+        assert "freezed_annotation" in runtime_dependencies
+        assert "json_annotation" in runtime_dependencies
+        assert "collection" in runtime_dependencies
+        assert "intl" in runtime_dependencies
+        assert "uuid" in runtime_dependencies
+        # sqlite packages
         assert "drift" in runtime_dependencies
+        # firebase packages
         assert "firebase_core" in runtime_dependencies
         assert "firebase_auth" in runtime_dependencies
         assert "cloud_firestore" in runtime_dependencies
         assert "firebase_messaging" in runtime_dependencies
+        # clean arch dev packages
+        assert "riverpod_generator" in dev_dependencies
+        assert "freezed" in dev_dependencies
+        assert "json_serializable" in dev_dependencies
+        # sqlite dev packages
         assert "drift_dev" in dev_dependencies
         assert "build_runner" in dev_dependencies
         assert "mocktail" in dev_dependencies
+
+    def test_dependency_selection_basic_architecture(self, config: Config) -> None:
+        """Test that clean-arch packages are absent for basic architecture."""
+        config.architecture = "basic"
+        bootstrap = ProjectBootstrap(config)
+
+        runtime_dependencies = bootstrap._runtime_dependencies()
+        dev_dependencies = bootstrap._dev_dependencies()
+
+        assert "go_router" not in runtime_dependencies
+        assert "riverpod_annotation" not in runtime_dependencies
+        assert "freezed_annotation" not in runtime_dependencies
+        assert "riverpod_generator" not in dev_dependencies
+        assert "freezed" not in dev_dependencies
+        assert "json_serializable" not in dev_dependencies
 
     # --- _detect_flutter_version ---
 


### PR DESCRIPTION
## Summary

Fixes seven issues found in projects generated by `flutter-setup` (documented in `sujiko/tasks/flutter-setup.md`). All changes are in `flutter_setup/bootstrap.py` with matching tests. Coverage held at ~91.36% (289 tests, up from 272).

- **FS-001** — `drift_dev` version constraint now tracks the full drift version (e.g. `^2.31.0`) instead of just the major (`^2.0.0`), preventing incompatible codegen.
- **FS-002** — Clean architecture projects now receive the full recommended package set: `go_router`, `riverpod_annotation`, `freezed_annotation`, `json_annotation`, `collection`, `intl`, `uuid` (runtime) and `riverpod_generator`, `freezed`, `json_serializable` (dev).
- **FS-004** — `build_runner` is automatically invoked at bootstrap time for `sqlite` and `clean` architecture projects so the project compiles immediately. README gains a _Code generation_ section with `make generate`.
- **FS-005** — The `app.dart` scaffold title is set to the project name instead of the hardcoded `'Flutter App'`.
- **FS-006** — `pubspec.yaml` description is updated from the generic Flutter placeholder to a project-specific string.
- **FS-007** — `app.dart` now uses `MaterialApp.router` backed by a generated `router.dart` (GoRouter with a home route), consistent with the architecture docs' requirement for named routes.
- **FS-011** — `assets/images/` and `assets/fonts/` are created (with `.gitkeep` sentinels) and `assets/images/` is declared in `pubspec.yaml` `flutter.assets`.

## Test plan

- [x] `make test` passes with 289 tests, 91.36% coverage (≥ 75% threshold)
- [x] Each fix has dedicated unit tests asserting the new behaviour
- [x] Existing tests updated where assertions were too loose (e.g. drift_dev version, README content)
- [x] Pre-commit hooks (black, ruff, mypy) pass on all commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)