### PR TITLE
fix: use emulator device target in generated run-android Makefile target

### DIFF
--- a/flutter_setup/bootstrap.py
+++ b/flutter_setup/bootstrap.py
@@ -297,7 +297,7 @@ setup-emulator:
         if "android" in self.config.platforms:
             android_target = (
                 f"run-android:{version_dep}{android_sdk_dep}\n"
-                f"{run_android_emulator_check}\t{flutter_cmd} run -d android\n\n"
+                f"{run_android_emulator_check}\t{flutter_cmd} run -d emulator\n\n"
             )
 
         return f"""{version_header}{android_sdk_header}{web_target}{ios_target}{android_target}analyze:{version_dep}{codegen_dep}


### PR DESCRIPTION
## Summary

- `flutter run -d android` does not match emulator device IDs (e.g. `emulator-5554`) in Flutter 3.32+
- Changed the Makefile generator to emit `flutter run -d emulator`, which correctly matches running emulator devices by ID prefix

## Test plan

- [ ] Run `flutter-setup` to generate a new project with Android platform
- [ ] Verify the generated `Makefile` contains `flutter run -d emulator` in the `run-android` target
- [ ] Run `make run-android` and confirm it launches on the emulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)