### PR TITLE
feat: add --e2e-testing option with patrol and integration_test support

### DIFF
--- a/PATROL_E2E_PLAN.md
+++ b/PATROL_E2E_PLAN.md
@@ -1,0 +1,148 @@
+# Add Patrol as an End-to-End Test Option
+
+## Goal
+
+Add an end-to-end testing selection that is independent of the existing unit/widget
+testing scaffold. The default Flutter end-to-end framework should remain available
+as `integration_test`, and Patrol should be selectable for projects that need
+native platform automation.
+
+References:
+
+- Flutter integration testing concepts: https://docs.flutter.dev/cookbook/testing/integration/introduction
+- Flutter integration test guide: https://docs.flutter.dev/testing/integration-tests
+- Patrol documentation: https://patrol.leancode.co/documentation
+
+## Product Shape
+
+Use a new option named `--e2e-testing` for both `create` and `append`.
+
+Allowed values:
+
+- `integration_test`: default. Uses Flutter SDK `integration_test`.
+- `patrol`: adds Patrol setup in addition to the normal Flutter integration test
+  structure where useful.
+
+Keep `--testing` unchanged. It controls unit/widget starter choices such as
+`standard` and `mocktail`.
+
+Document this as its own "End-to-End Testing" section immediately after the
+unit/widget testing section in the `create` and `append` command docs. In the
+README options table, place `--e2e-testing` directly after `--testing`.
+
+## Implementation Plan
+
+1. Add configuration support.
+   - Add `E2ETesting = Literal["integration_test", "patrol"]` in
+     `flutter_setup/config.py`.
+   - Add `e2e_testing: E2ETesting = "integration_test"` to `Config`.
+   - Validate the value in `Config._validate()`.
+   - Add `e2e_testing: integration_test` to the default config in
+     `flutter_setup/config_manager.py`.
+   - Preserve `e2e_testing` in `flutter-setup init` when an existing config file
+     already contains it.
+
+2. Add CLI support for `create`.
+   - Import `E2ETesting` in `flutter_setup/cli.py`.
+   - Add `--e2e-testing` after `--testing` in the `create` command definition.
+   - Merge CLI, config, and prompt values using the existing
+     `get_merged_or_prompt()` pattern.
+   - Prompt label: `End-to-end testing framework`.
+   - Pass `e2e_testing=merged_e2e_testing` into `Config`.
+
+3. Add CLI support for `append`.
+   - Add `--e2e-testing` after `--testing` in the `append` command definition.
+   - For existing Flutter projects, include the selected value in the `Config`
+     used by `ProjectBootstrap.append_project()`.
+   - For non-Flutter directories that route to full setup, pass it into `Config`.
+   - Prefer config-file values when the user did not explicitly pass the option,
+     matching the intent of the existing `append` config merge behavior.
+
+4. Generate project files for `integration_test`.
+   - Keep the current `integration_test/` directory and
+     `integration_test/app_test.dart` sample.
+   - Keep adding `integration_test: {sdk: flutter}` to `dev_dependencies`.
+   - Keep the Makefile `integration` target as:
+     `flutter test integration_test`.
+
+5. Generate project files for `patrol`.
+   - Add a `patrol_test/` directory and sample `patrol_test/app_test.dart`.
+   - Add `patrol` as a dev dependency when `e2e_testing == "patrol"`.
+   - Add a helper that writes the required `patrol:` pubspec section with:
+     `app_name`, Android package name when Android is selected, iOS bundle id
+     when iOS is selected, and macOS bundle id when macOS is selected.
+   - Derive identifiers from existing config conventions:
+     `android.package_name = {org}.{package_name}`,
+     `ios.bundle_id = {org}.{package_name}`,
+     `macos.bundle_id = {org}.{package_name}`.
+   - Add Patrol-generated and local-secret files to `.gitignore`:
+     `**/test_bundle.dart` and `.patrol.env`.
+   - Add a Makefile target after `integration`:
+     `patrol-test: ...`
+     `patrol test -t patrol_test/app_test.dart`
+   - Add a `patrol-doctor` target:
+     `patrol doctor`
+   - Consider keeping `integration` even when Patrol is selected so projects can
+     still run the default Flutter framework.
+
+6. Append behavior.
+   - `_append_makefile()` should naturally append new Patrol targets because it
+     filters by target name.
+   - `append_project()` currently avoids mutating `pubspec.yaml` and source
+     files. Decide explicitly whether `append --e2e-testing patrol` may update
+     `pubspec.yaml` and `.gitignore`.
+   - Recommended behavior: allow only additive, idempotent updates for Patrol
+     when explicitly selected. Do not overwrite existing `patrol:` config or
+     test files unless `--force` is used.
+   - Add console output that distinguishes "Makefile targets appended" from
+     "Patrol e2e scaffold added".
+
+7. README and generated README updates.
+   - Add a README "End-to-End Testing" subsection after the unit/widget testing
+     content.
+   - List `integration_test` as the default Flutter SDK option.
+   - List `patrol` as the option for native UI automation, permission dialogs,
+     notifications, and platform views.
+   - Add examples:
+     `flutter-setup create MyApp ios android --e2e-testing patrol`
+     `flutter-setup append --dir ./MyApp --e2e-testing patrol`
+   - Update generated README text in `ProjectBootstrap._create_readme()` and
+     `_append_readme()` to show `make integration`, and conditionally show
+     `make patrol-test` / `make patrol-doctor`.
+
+8. Tests.
+   - `tests/test_config.py`: default `e2e_testing`, valid values, invalid value.
+   - `tests/test_cli.py`: `create --e2e-testing patrol` reaches `Config`; config
+     file value is honored; interactive prompt order puts e2e after testing.
+   - `tests/test_cli.py` or `tests/test_e2e_create_append.py`: `append
+     --e2e-testing patrol` reaches `ProjectBootstrap`.
+   - `tests/test_bootstrap.py`: Makefile includes default `integration` and
+     Patrol targets when selected.
+   - `tests/test_bootstrap.py`: Patrol dev dependency and `patrol:` pubspec
+     section are added idempotently.
+   - `tests/test_bootstrap.py`: `.gitignore` gains `**/test_bundle.dart` and
+     `.patrol.env` without duplicates.
+   - `tests/test_e2e_fixtures.py`: append with default config preserves existing
+     files; append with Patrol selected performs only the explicitly allowed
+     additive changes.
+
+9. Verification.
+   - Run `uv run pytest`.
+   - Run `uv run ruff check .`.
+   - Run `uv run mypy .`.
+   - Optionally run `uv run flutter-setup create --help` and
+     `uv run flutter-setup append --help` to confirm option ordering and help
+     text.
+
+## Open Decisions
+
+- Should `append --e2e-testing patrol` mutate `pubspec.yaml` by default, or
+  should it only append Makefile/README guidance and require a separate explicit
+  setup command later?
+- Should Patrol use its default `patrol_test/` directory, or configure
+  `test_directory: integration_test` so all end-to-end tests stay in one
+  directory? The docs support either; `patrol_test/` is clearer for generated
+  projects because both frameworks remain visible.
+- Should the Patrol sample pump the app directly, or should generated projects
+  expose a reusable app factory to reduce duplication between widget,
+  integration, and Patrol tests?

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ flutter-setup append MyApp --dir ./projects
 | `--architecture` | Application architecture scaffold (basic/clean) | `basic` | ✅ |
 | `--database` | Local persistence scaffold (none/sqlite) | `none` | ✅ |
 | `--testing` | Testing starter scaffold (standard/mocktail) | `standard` | ✅ |
+| `--e2e-testing` | End-to-end testing framework (integration_test/patrol) | `integration_test` | ✅ |
 | `--auth-provider` | Auth integration scaffold (none/firebase) | `none` | ✅ |
 | `--cloud-database` | Cloud database scaffold (none/firestore) | `none` | ✅ |
 | `--notifications-provider` | Push notifications scaffold (none/firebase) | `none` | ✅ |
@@ -148,6 +149,7 @@ flutter-setup append MyApp --dir ./projects
 - ✅ Optional SQLite/Drift local persistence scaffold
 - ✅ Optional Firebase Auth, Firestore, and Firebase Messaging scaffolds
 - ✅ Optional Mocktail testing starter
+- ✅ Optional Patrol end-to-end testing scaffold
 
 ### 4. Development Environment
 - ✅ VS Code/Cursor configuration
@@ -169,6 +171,7 @@ MyAwesomeApp/
 │   ├── unit/               # Unit tests
 │   └── widget/             # Widget tests
 ├── integration_test/        # Integration tests
+├── patrol_test/             # Patrol tests (when --e2e-testing patrol)
 ├── Makefile                 # Common development commands
 ├── analysis_options.yaml    # Linting and analysis rules
 ├── .env                     # Environment variables
@@ -188,6 +191,10 @@ make run_android      # Android emulator
 # Testing
 make test             # Unit + widget tests
 make integration      # Integration tests
+
+# End-to-end testing
+make patrol-test      # Patrol tests when --e2e-testing patrol
+make patrol-doctor    # Patrol environment diagnostics
 
 # Code quality
 make analyze          # Flutter analyze
@@ -212,6 +219,7 @@ project:
   architecture: basic
   database: none
   testing: standard
+  e2e_testing: integration_test
   auth_provider: none
   cloud_database: none
   notifications_provider: none

--- a/flutter_setup/bootstrap.py
+++ b/flutter_setup/bootstrap.py
@@ -1145,7 +1145,9 @@ class FirebaseNotificationsService {
             with open(pubspec_path, "r") as f:
                 pubspec = yaml.safe_load(f) or {}
             dev_deps = pubspec.setdefault("dev_dependencies", {})
-            dev_deps.setdefault("patrol", "any")
+            if "patrol" in dev_deps:
+                return
+            dev_deps["patrol"] = "any"
             with open(pubspec_path, "w") as f:
                 yaml.dump(pubspec, f, default_flow_style=False, sort_keys=False)
         except Exception as e:
@@ -1161,20 +1163,27 @@ class FirebaseNotificationsService {
         try:
             with open(pubspec_path, "r") as f:
                 pubspec = yaml.safe_load(f) or {}
+            original = yaml.dump(pubspec, default_flow_style=False, sort_keys=False)
             patrol_config = pubspec.setdefault("patrol", {})
             patrol_config.setdefault("app_name", self.config.project_name)
-            package_id = f"{self.config.org}.{self.config.package_name}"
+            # Apple bundle identifiers must not contain underscores.
+            safe_package = self.config.package_name.replace("_", "-")
+            package_id = f"{self.config.org}.{safe_package}"
+            android_id = f"{self.config.org}.{self.config.package_name}"
             if "android" in self.config.platforms:
                 android = patrol_config.setdefault("android", {})
-                android.setdefault("package_name", package_id)
+                android.setdefault("package_name", android_id)
             if "ios" in self.config.platforms:
                 ios = patrol_config.setdefault("ios", {})
                 ios.setdefault("bundle_id", package_id)
             if "macos" in self.config.platforms:
                 macos = patrol_config.setdefault("macos", {})
                 macos.setdefault("bundle_id", package_id)
+            updated = yaml.dump(pubspec, default_flow_style=False, sort_keys=False)
+            if updated == original:
+                return
             with open(pubspec_path, "w") as f:
-                yaml.dump(pubspec, f, default_flow_style=False, sort_keys=False)
+                f.write(updated)
         except Exception as e:
             console.print(f"  ⚠️  Failed to add Patrol config: {e}")
 

--- a/flutter_setup/bootstrap.py
+++ b/flutter_setup/bootstrap.py
@@ -114,6 +114,9 @@ class ProjectBootstrap:
         # Add dependencies
         self._add_dependencies()
 
+        # Create optional end-to-end test scaffolds
+        self._create_e2e_scaffold()
+
         # Update pubspec description (flutter create leaves a generic placeholder)
         self._update_pubspec_description()
 
@@ -300,6 +303,8 @@ setup-emulator:
                 f"{run_android_emulator_check}\t{flutter_cmd} run -d android\n\n"
             )
 
+        e2e_targets = self._build_e2e_makefile_targets(version_dep, codegen_dep)
+
         return f"""{version_header}{android_sdk_header}{web_target}{ios_target}{android_target}analyze:{version_dep}{codegen_dep}
 \t{flutter_cmd} analyze
 
@@ -309,12 +314,25 @@ test:{version_dep}{codegen_dep}
 integration:{version_dep}{codegen_dep}
 \t{flutter_cmd} test integration_test
 
+{e2e_targets}
 upgrade:{version_dep}
 \t{flutter_cmd} pub upgrade
 
 upgrade-check:{version_dep}
 \t{flutter_cmd} pub get
 {generate_target}{android_sdk_target}{version_target}"""
+
+    def _build_e2e_makefile_targets(self, version_dep: str, codegen_dep: str) -> str:
+        """Return optional Makefile targets for selected end-to-end tooling."""
+        if self.config.e2e_testing != "patrol":
+            return ""
+
+        return f"""patrol-test:{version_dep}{codegen_dep}
+\tpatrol test -t patrol_test/app_test.dart
+
+patrol-doctor:
+\tpatrol doctor
+"""
 
     def _create_makefile(self) -> None:
         """Create Makefile with common commands."""
@@ -401,6 +419,7 @@ upgrade-check:{version_dep}
         console.print("  🔧 Appending flutter-setup tooling...")
         self._append_vscode_config()
         self._append_makefile()
+        self._create_e2e_scaffold()
         self._create_cicd()
         self._append_readme()
         console.print("  ✅ Tooling appended")
@@ -538,6 +557,62 @@ void main() {{
             self.config.project_path / "integration_test" / "app_test.dart", "w"
         ) as f:
             f.write(integration_test)
+
+    def _create_e2e_scaffold(self) -> None:
+        """Create optional end-to-end test scaffolds."""
+        if self.config.e2e_testing == "patrol":
+            self._create_patrol_scaffold()
+
+    def _create_patrol_scaffold(self) -> None:
+        """Create Patrol end-to-end test support."""
+        self._create_patrol_sample_test()
+        self._add_patrol_to_pubspec()
+        self._add_patrol_config_to_pubspec()
+        self._add_patrol_to_gitignore()
+        console.print("  ✅ Patrol end-to-end scaffold created")
+
+    def _create_patrol_sample_test(self) -> None:
+        """Create a sample Patrol test unless one already exists."""
+        patrol_dir = self.config.project_path / "patrol_test"
+        patrol_dir.mkdir(exist_ok=True)
+        test_file = patrol_dir / "app_test.dart"
+        if test_file.exists() and not self.force:
+            return
+
+        app_import = f"package:{self.config.package_name}/main.dart"
+        app_widget = "MyApp"
+        riverpod_import = ""
+        pump_widget = f"const {app_widget}()"
+        if self.config.architecture == "clean":
+            app_import = f"package:{self.config.package_name}/src/app/app.dart"
+            app_widget = "App"
+            riverpod_import = (
+                "import 'package:flutter_riverpod/flutter_riverpod.dart';\n"
+            )
+            pump_widget = f"const ProviderScope(child: {app_widget}())"
+
+        assertion = (
+            "expect(find.text('Home'), findsOneWidget);"
+            if self.config.architecture == "clean"
+            else f"expect(find.byType({app_widget}), findsOneWidget);"
+        )
+
+        test_file.write_text(f"""import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:patrol/patrol.dart';
+{riverpod_import}import '{app_import}';
+
+void main() {{
+  setUpAll(() async {{
+    await dotenv.load(fileName: '.env', isOptional: true);
+  }});
+
+  patrolTest('home page renders', ($) async {{
+    await $.pumpWidgetAndSettle({pump_widget});
+    {assertion}
+  }});
+}}
+""")
 
     def _create_analysis_options(self) -> None:
         """Create analysis options file."""
@@ -952,6 +1027,9 @@ class FirebaseNotificationsService {
         if self.config.testing == "mocktail":
             dependencies.append("mocktail")
 
+        if self.config.e2e_testing == "patrol":
+            dependencies.append("patrol")
+
         return dependencies
 
     _GENERIC_PUBSPEC_DESCRIPTION = "A new Flutter project."
@@ -1038,6 +1116,50 @@ class FirebaseNotificationsService {
         except Exception as e:
             console.print(f"  ⚠️  Failed to add integration_test SDK dependency: {e}")
 
+    def _add_patrol_to_pubspec(self) -> None:
+        """Ensure Patrol is present in pubspec.yaml dev_dependencies."""
+        pubspec_path = self.config.project_path / "pubspec.yaml"
+        if not pubspec_path.exists():
+            console.print("  ⚠️  pubspec.yaml not found, skipping Patrol dependency")
+            return
+
+        try:
+            with open(pubspec_path, "r") as f:
+                pubspec = yaml.safe_load(f) or {}
+            dev_deps = pubspec.setdefault("dev_dependencies", {})
+            dev_deps.setdefault("patrol", "any")
+            with open(pubspec_path, "w") as f:
+                yaml.dump(pubspec, f, default_flow_style=False, sort_keys=False)
+        except Exception as e:
+            console.print(f"  ⚠️  Failed to add Patrol dependency: {e}")
+
+    def _add_patrol_config_to_pubspec(self) -> None:
+        """Ensure the Patrol pubspec.yaml section exists."""
+        pubspec_path = self.config.project_path / "pubspec.yaml"
+        if not pubspec_path.exists():
+            console.print("  ⚠️  pubspec.yaml not found, skipping Patrol config")
+            return
+
+        try:
+            with open(pubspec_path, "r") as f:
+                pubspec = yaml.safe_load(f) or {}
+            patrol_config = pubspec.setdefault("patrol", {})
+            patrol_config.setdefault("app_name", self.config.project_name)
+            package_id = f"{self.config.org}.{self.config.package_name}"
+            if "android" in self.config.platforms:
+                android = patrol_config.setdefault("android", {})
+                android.setdefault("package_name", package_id)
+            if "ios" in self.config.platforms:
+                ios = patrol_config.setdefault("ios", {})
+                ios.setdefault("bundle_id", package_id)
+            if "macos" in self.config.platforms:
+                macos = patrol_config.setdefault("macos", {})
+                macos.setdefault("bundle_id", package_id)
+            with open(pubspec_path, "w") as f:
+                yaml.dump(pubspec, f, default_flow_style=False, sort_keys=False)
+        except Exception as e:
+            console.print(f"  ⚠️  Failed to add Patrol config: {e}")
+
     def _add_drift_dev_to_pubspec(self) -> None:
         """Write drift_dev directly to pubspec.yaml dev_dependencies for sqlite projects.
 
@@ -1115,6 +1237,28 @@ API_URL=https://api.example.com
                 f.write(entry)
         else:
             gitignore_path.write_text(f"# Environment variables\n{entry}")
+
+    def _add_patrol_to_gitignore(self) -> None:
+        """Ensure Patrol-generated files and local secrets are gitignored."""
+        gitignore_path = self.config.project_path / ".gitignore"
+        entries = ["**/test_bundle.dart", ".patrol.env"]
+        existing = gitignore_path.read_text() if gitignore_path.exists() else ""
+        existing_lines = {line.strip() for line in existing.splitlines()}
+        missing = [entry for entry in entries if entry not in existing_lines]
+        if not missing:
+            return
+
+        if gitignore_path.exists():
+            with open(gitignore_path, "a") as f:
+                if existing and not existing.endswith("\n"):
+                    f.write("\n")
+                f.write("\n# Patrol\n")
+                for entry in missing:
+                    f.write(f"{entry}\n")
+        else:
+            gitignore_path.write_text(
+                "# Patrol\n" + "".join(f"{entry}\n" for entry in missing)
+            )
 
     def _add_env_asset_to_pubspec(self) -> None:
         """Add .env to the flutter assets list in pubspec.yaml."""
@@ -1232,6 +1376,12 @@ make generate
 ```
 """
 
+        e2e_commands = "make integration    # Flutter SDK integration_test/"
+        if self.config.e2e_testing == "patrol":
+            e2e_commands += """
+make patrol-test    # Patrol native end-to-end tests
+make patrol-doctor  # Patrol environment diagnostics"""
+
         return f"""## flutter-setup
 
 ### Quickstart
@@ -1243,7 +1393,11 @@ flutter pub get
 ### Testing
 ```bash
 make test           # unit + widget tests
-make integration    # integration_test/
+```
+
+### End-to-End Testing
+```bash
+{e2e_commands}
 ```
 
 ### Linting
@@ -1261,6 +1415,7 @@ or use `--dart-define-from-file=.env.json` for build-time injection.
 - Architecture: `{self.config.architecture}`
 - Database: `{self.config.database}`
 - Testing: `{self.config.testing}`
+- End-to-end testing: `{self.config.e2e_testing}`
 - Auth provider: `{self.config.auth_provider}`
 - Cloud database: `{self.config.cloud_database}`
 - Notifications: `{self.config.notifications_provider}`

--- a/flutter_setup/cli.py
+++ b/flutter_setup/cli.py
@@ -916,7 +916,9 @@ def append_command(
         if ctx.get_parameter_source(
             "e2e_testing"
         ) != click.core.ParameterSource.COMMANDLINE and file_project.get("e2e_testing"):
-            e2e_testing = cast(E2ETesting, file_project["e2e_testing"])
+            raw = str(file_project["e2e_testing"]).lower()
+            if raw in ("integration_test", "patrol"):
+                e2e_testing = cast(E2ETesting, raw)
 
         target_path = Path(target_dir).resolve()
         is_flutter = detect_flutter_project(target_path)

--- a/flutter_setup/cli.py
+++ b/flutter_setup/cli.py
@@ -26,6 +26,7 @@ from .config import (
     Architecture,
     Database,
     Testing,
+    E2ETesting,
     AuthProvider,
     CloudDatabase,
     NotificationsProvider,
@@ -172,6 +173,7 @@ def init_config(force: bool) -> None:
                     "architecture",
                     "database",
                     "testing",
+                    "e2e_testing",
                     "auth_provider",
                     "cloud_database",
                     "notifications_provider",
@@ -331,6 +333,12 @@ def check_command(verbose: bool) -> None:
     help="Testing starter scaffold (default: standard)",
 )
 @click.option(
+    "--e2e-testing",
+    type=click.Choice(["integration_test", "patrol"]),
+    default="integration_test",
+    help="End-to-end testing framework (default: integration_test)",
+)
+@click.option(
     "--auth-provider",
     type=click.Choice(["none", "firebase"]),
     default="none",
@@ -394,6 +402,7 @@ def create_command(
     architecture: Architecture,
     database: Database,
     testing: Testing,
+    e2e_testing: E2ETesting,
     auth_provider: AuthProvider,
     cloud_database: CloudDatabase,
     notifications_provider: NotificationsProvider,
@@ -552,6 +561,16 @@ def create_command(
                 choices=["standard", "mocktail"],
             ),
         )
+        merged_e2e_testing = cast(
+            E2ETesting,
+            get_merged_or_prompt(
+                "e2e_testing",
+                e2e_testing,
+                file_project,
+                "End-to-end testing framework",
+                choices=["integration_test", "patrol"],
+            ),
+        )
         merged_auth_provider = cast(
             AuthProvider,
             get_merged_or_prompt(
@@ -641,6 +660,7 @@ def create_command(
             architecture=merged_architecture,
             database=merged_database,
             testing=merged_testing,
+            e2e_testing=merged_e2e_testing,
             auth_provider=merged_auth_provider,
             cloud_database=merged_cloud_database,
             notifications_provider=merged_notifications_provider,
@@ -724,6 +744,12 @@ def create_command(
     help="Testing starter scaffold (default: standard)",
 )
 @click.option(
+    "--e2e-testing",
+    type=click.Choice(["integration_test", "patrol"]),
+    default="integration_test",
+    help="End-to-end testing framework (default: integration_test)",
+)
+@click.option(
     "--auth-provider",
     type=click.Choice(["none", "firebase"]),
     default="none",
@@ -775,7 +801,9 @@ def create_command(
     is_flag=True,
     help="Enable verbose output",
 )
+@click.pass_context
 def append_command(
+    ctx: click.Context,
     project_name: str | None,
     target_dir: str,
     force: bool,
@@ -785,6 +813,7 @@ def append_command(
     architecture: Architecture,
     database: Database,
     testing: Testing,
+    e2e_testing: E2ETesting,
     auth_provider: AuthProvider,
     cloud_database: CloudDatabase,
     notifications_provider: NotificationsProvider,
@@ -824,6 +853,10 @@ def append_command(
             org = file_project["org"]
         if channel == "stable" and file_flutter.get("channel"):
             channel = cast(FlutterChannel, file_flutter["channel"])
+        if ctx.get_parameter_source(
+            "e2e_testing"
+        ) != click.core.ParameterSource.COMMANDLINE and file_project.get("e2e_testing"):
+            e2e_testing = cast(E2ETesting, file_project["e2e_testing"])
 
         target_path = Path(target_dir).resolve()
         is_flutter = detect_flutter_project(target_path)
@@ -849,6 +882,7 @@ def append_command(
                 architecture=architecture,
                 database=database,
                 testing=testing,
+                e2e_testing=e2e_testing,
                 auth_provider=auth_provider,
                 cloud_database=cloud_database,
                 notifications_provider=notifications_provider,
@@ -905,6 +939,7 @@ def append_command(
                 architecture=architecture,
                 database=database,
                 testing=testing,
+                e2e_testing=e2e_testing,
                 auth_provider=auth_provider,
                 cloud_database=cloud_database,
                 notifications_provider=notifications_provider,

--- a/flutter_setup/config.py
+++ b/flutter_setup/config.py
@@ -14,6 +14,7 @@ Platform = Literal["ios", "android", "macos", "linux", "windows", "web"]
 Architecture = Literal["basic", "clean"]
 Database = Literal["none", "sqlite"]
 Testing = Literal["standard", "mocktail"]
+E2ETesting = Literal["integration_test", "patrol"]
 AuthProvider = Literal["none", "firebase"]
 CloudDatabase = Literal["none", "firestore"]
 NotificationsProvider = Literal["none", "firebase"]
@@ -38,6 +39,7 @@ class Config:
     architecture: Architecture = "basic"
     database: Database = "none"
     testing: Testing = "standard"
+    e2e_testing: E2ETesting = "integration_test"
     auth_provider: AuthProvider = "none"
     cloud_database: CloudDatabase = "none"
     notifications_provider: NotificationsProvider = "none"
@@ -79,6 +81,11 @@ class Config:
 
         if self.testing not in ["standard", "mocktail"]:
             raise ValueError(f"Invalid testing framework: {self.testing}")
+
+        if self.e2e_testing not in ["integration_test", "patrol"]:
+            raise ValueError(
+                f"Invalid end-to-end testing framework: {self.e2e_testing}"
+            )
 
         if self.auth_provider not in ["none", "firebase"]:
             raise ValueError(f"Invalid auth provider: {self.auth_provider}")

--- a/flutter_setup/config_manager.py
+++ b/flutter_setup/config_manager.py
@@ -51,6 +51,7 @@ class ConfigManager:
                 "architecture": "basic",
                 "database": "none",
                 "testing": "standard",
+                "e2e_testing": "integration_test",
                 "auth_provider": "none",
                 "cloud_database": "none",
                 "notifications_provider": "none",

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -109,6 +109,36 @@ class TestProjectBootstrap:
             assert "generate:" in content
             assert "build_runner" in content
 
+    def test_create_makefile_includes_patrol_targets_when_selected(
+        self, config: Config
+    ) -> None:
+        """Test that Patrol Makefile targets are created when selected."""
+        config.e2e_testing = "patrol"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.output_dir = Path(tmpdir)
+            config.project_path.mkdir(parents=True, exist_ok=True)
+            bootstrap = ProjectBootstrap(config)
+            bootstrap._create_makefile()
+            content = (config.project_path / "Makefile").read_text()
+            assert "integration:" in content
+            assert "flutter test integration_test" in content
+            assert "patrol-test:" in content
+            assert "patrol test -t patrol_test/app_test.dart" in content
+            assert "patrol-doctor:" in content
+
+    def test_create_makefile_omits_patrol_targets_by_default(
+        self, config: Config
+    ) -> None:
+        """Test that Patrol targets are absent for the default e2e framework."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.output_dir = Path(tmpdir)
+            config.project_path.mkdir(parents=True, exist_ok=True)
+            bootstrap = ProjectBootstrap(config)
+            bootstrap._create_makefile()
+            content = (config.project_path / "Makefile").read_text()
+            assert "integration:" in content
+            assert "patrol-test:" not in content
+
     def test_check_flutter_version_target_verifies_version(
         self, config: Config
     ) -> None:
@@ -216,6 +246,61 @@ class TestProjectBootstrap:
             # swallows unexpected errors (encoding faults, asset misconfig, etc.)
             assert "isOptional: true" in content
             assert "catch (_)" not in content
+
+    def test_create_patrol_scaffold(self, config: Config) -> None:
+        """Test creating Patrol scaffold files and pubspec entries."""
+        config.e2e_testing = "patrol"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.output_dir = Path(tmpdir)
+            config.project_path.mkdir(parents=True, exist_ok=True)
+            (config.project_path / "pubspec.yaml").write_text(
+                "name: test_app\ndev_dependencies:\n  flutter_test:\n"
+                "    sdk: flutter\n"
+            )
+            bootstrap = ProjectBootstrap(config)
+            bootstrap._create_e2e_scaffold()
+
+            patrol_test = config.project_path / "patrol_test" / "app_test.dart"
+            assert patrol_test.exists()
+            assert "patrolTest" in patrol_test.read_text()
+
+            pubspec = yaml.safe_load((config.project_path / "pubspec.yaml").read_text())
+            assert pubspec["dev_dependencies"]["patrol"] == "any"
+            assert pubspec["patrol"]["app_name"] == "TestApp"
+            assert pubspec["patrol"]["android"]["package_name"] == "com.test.testapp"
+            assert pubspec["patrol"]["ios"]["bundle_id"] == "com.test.testapp"
+
+            gitignore = (config.project_path / ".gitignore").read_text()
+            assert "**/test_bundle.dart" in gitignore
+            assert ".patrol.env" in gitignore
+
+    def test_patrol_pubspec_updates_are_idempotent(self, config: Config) -> None:
+        """Test Patrol pubspec updates preserve existing explicit values."""
+        config.e2e_testing = "patrol"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.output_dir = Path(tmpdir)
+            config.project_path.mkdir(parents=True, exist_ok=True)
+            (config.project_path / "pubspec.yaml").write_text(
+                "name: test_app\n"
+                "dev_dependencies:\n"
+                "  patrol: ^3.0.0\n"
+                "patrol:\n"
+                "  app_name: Custom App\n"
+                "  android:\n"
+                "    package_name: com.custom.app\n"
+            )
+            bootstrap = ProjectBootstrap(config)
+            bootstrap._create_e2e_scaffold()
+            bootstrap._create_e2e_scaffold()
+
+            pubspec = yaml.safe_load((config.project_path / "pubspec.yaml").read_text())
+            assert pubspec["dev_dependencies"]["patrol"] == "^3.0.0"
+            assert pubspec["patrol"]["app_name"] == "Custom App"
+            assert pubspec["patrol"]["android"]["package_name"] == "com.custom.app"
+
+            gitignore = (config.project_path / ".gitignore").read_text()
+            assert gitignore.count("**/test_bundle.dart") == 1
+            assert gitignore.count(".patrol.env") == 1
 
     def test_create_analysis_options(self, config: Config) -> None:
         """Test creating analysis options file."""
@@ -1202,6 +1287,7 @@ class TestProjectBootstrap:
         config.architecture = "clean"
         config.database = "sqlite"
         config.testing = "mocktail"
+        config.e2e_testing = "patrol"
         config.auth_provider = "firebase"
         config.cloud_database = "firestore"
         config.notifications_provider = "firebase"
@@ -1234,6 +1320,7 @@ class TestProjectBootstrap:
         assert "drift_dev" in dev_dependencies
         assert "build_runner" in dev_dependencies
         assert "mocktail" in dev_dependencies
+        assert "patrol" in dev_dependencies
 
     def test_dependency_selection_basic_architecture(self, config: Config) -> None:
         """Test that clean-arch packages are absent for basic architecture."""
@@ -1249,6 +1336,7 @@ class TestProjectBootstrap:
         assert "riverpod_generator" not in dev_dependencies
         assert "freezed" not in dev_dependencies
         assert "json_serializable" not in dev_dependencies
+        assert "patrol" not in dev_dependencies
 
     def test_clean_arch_without_sqlite_includes_build_runner(
         self, config: Config

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -160,7 +160,8 @@ class TestCLI:
                 mock_setup = Mock()
                 mock_setup_class.return_value = mock_setup
                 # Prompts in order: project name, platforms, template, architecture,
-                # database, testing, auth_provider, cloud_database, notifications_provider.
+                # database, testing, e2e_testing, auth_provider, cloud_database,
+                # notifications_provider.
                 # ios/android language are NOT prompted because template="app".
                 user_input = (
                     "\n".join(
@@ -171,6 +172,7 @@ class TestCLI:
                             "clean",
                             "sqlite",
                             "mocktail",
+                            "patrol",
                             "none",
                             "none",
                             "none",
@@ -189,6 +191,7 @@ class TestCLI:
                 assert config.architecture == "clean"
                 assert config.database == "sqlite"
                 assert config.testing == "mocktail"
+                assert config.e2e_testing == "patrol"
 
     def test_create_command_plugin_template_prompts_languages(self) -> None:
         """ios/android language prompts appear only for plugin template."""
@@ -215,6 +218,7 @@ class TestCLI:
                             "basic",  # architecture
                             "none",  # database
                             "standard",  # testing
+                            "integration_test",  # e2e_testing
                             "none",  # auth_provider
                             "none",  # cloud_database
                             "none",  # notifications_provider
@@ -231,6 +235,7 @@ class TestCLI:
                 assert result.exit_code == 0
                 config = mock_setup_class.call_args.args[0]
                 assert config.template == "plugin"
+                assert config.e2e_testing == "integration_test"
                 assert config.ios_language == "objc"
                 assert config.android_language == "java"
 
@@ -252,6 +257,7 @@ class TestCLI:
                     "architecture": "basic",
                     "database": "none",
                     "testing": "standard",
+                    "e2e_testing": "integration_test",
                     "auth_provider": "none",
                     "cloud_database": "none",
                     "notifications_provider": "none",
@@ -306,6 +312,31 @@ class TestCLI:
                 config = mock_setup_class.call_args.args[0]
                 assert config.flutter_version == "3.24.0"
 
+    def test_create_command_with_patrol_e2e_testing(self) -> None:
+        """--e2e-testing is passed through to Config."""
+        runner = CliRunner()
+        with patch("flutter_setup.cli.ConfigManager") as mock_manager_class:
+            mock_manager = Mock()
+            mock_manager_class.return_value = mock_manager
+            mock_manager.load_config.return_value = {
+                "flutter": {
+                    "location": "/flutter",
+                    "channel": "stable",
+                    "update_mode": "skip",
+                },
+                "project": {"org": "com.example"},
+            }
+            with patch("flutter_setup.cli.FlutterSetup") as mock_setup_class:
+                mock_setup = Mock()
+                mock_setup_class.return_value = mock_setup
+                result = runner.invoke(
+                    cli,
+                    ["create", "TestApp", "ios", "--e2e-testing", "patrol"],
+                )
+                assert result.exit_code == 0
+                config = mock_setup_class.call_args.args[0]
+                assert config.e2e_testing == "patrol"
+
     def test_init_config_preserves_project_settings(self) -> None:
         """Re-running init preserves existing project settings like architecture."""
         runner = CliRunner()
@@ -321,6 +352,7 @@ class TestCLI:
                     "architecture": "clean",
                     "database": "sqlite",
                     "testing": "mocktail",
+                    "e2e_testing": "patrol",
                     "auth_provider": "firebase",
                     "cloud_database": "firestore",
                     "notifications_provider": "firebase",
@@ -339,6 +371,7 @@ class TestCLI:
                 assert saved["project"]["architecture"] == "clean"
                 assert saved["project"]["database"] == "sqlite"
                 assert saved["project"]["testing"] == "mocktail"
+                assert saved["project"]["e2e_testing"] == "patrol"
                 assert saved["project"]["auth_provider"] == "firebase"
                 assert saved["project"]["ios_language"] == "objc"
                 assert saved["project"]["android_language"] == "java"
@@ -544,6 +577,52 @@ class TestAppendCommand:
                         )
                         assert result.exit_code == 0
                         assert mock_bs_class.call_args.kwargs["force"] is True
+
+    def test_append_existing_flutter_project_with_patrol_e2e_testing(
+        self, tmp_path: Path
+    ) -> None:
+        """--e2e-testing is forwarded to append Config."""
+        runner = CliRunner()
+        with patch("flutter_setup.cli.ConfigManager") as mock_cm:
+            mock_cm.return_value.load_config.return_value = self._base_config()
+            with patch("flutter_setup.cli.detect_flutter_project", return_value=True):
+                with patch("flutter_setup.cli.detect_platforms", return_value=["ios"]):
+                    with patch("flutter_setup.cli.ProjectBootstrap") as mock_bs_class:
+                        mock_bs = Mock()
+                        mock_bs_class.return_value = mock_bs
+                        result = runner.invoke(
+                            cli,
+                            [
+                                "append",
+                                "--dir",
+                                str(tmp_path),
+                                "--e2e-testing",
+                                "patrol",
+                            ],
+                        )
+                        assert result.exit_code == 0
+                        config = mock_bs_class.call_args.args[0]
+                        assert config.e2e_testing == "patrol"
+
+    def test_append_existing_flutter_project_uses_config_e2e_testing(
+        self, tmp_path: Path
+    ) -> None:
+        """Config file e2e_testing is used when CLI option is omitted."""
+        runner = CliRunner()
+        with patch("flutter_setup.cli.ConfigManager") as mock_cm:
+            mock_cm.return_value.load_config.return_value = {
+                "flutter": {"location": "/flutter", "channel": "stable"},
+                "project": {"e2e_testing": "patrol"},
+            }
+            with patch("flutter_setup.cli.detect_flutter_project", return_value=True):
+                with patch("flutter_setup.cli.detect_platforms", return_value=["ios"]):
+                    with patch("flutter_setup.cli.ProjectBootstrap") as mock_bs_class:
+                        mock_bs = Mock()
+                        mock_bs_class.return_value = mock_bs
+                        result = runner.invoke(cli, ["append", "--dir", str(tmp_path)])
+                        assert result.exit_code == 0
+                        config = mock_bs_class.call_args.args[0]
+                        assert config.e2e_testing == "patrol"
 
     def test_append_non_flutter_with_project_name(self, tmp_path: Path) -> None:
         """Non-Flutter directory with project_name argument runs full FlutterSetup."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,6 +40,7 @@ class TestConfig:
         assert config.architecture == "basic"
         assert config.database == "none"
         assert config.testing == "standard"
+        assert config.e2e_testing == "integration_test"
         assert config.auth_provider == "none"
         assert config.cloud_database == "none"
         assert config.notifications_provider == "none"
@@ -299,6 +300,7 @@ class TestConfig:
             architecture="clean",
             database="sqlite",
             testing="mocktail",
+            e2e_testing="patrol",
             auth_provider="firebase",
             cloud_database="firestore",
             notifications_provider="firebase",
@@ -307,6 +309,7 @@ class TestConfig:
         assert config.architecture == "clean"
         assert config.database == "sqlite"
         assert config.testing == "mocktail"
+        assert config.e2e_testing == "patrol"
         assert config.auth_provider == "firebase"
         assert config.cloud_database == "firestore"
         assert config.notifications_provider == "firebase"
@@ -335,6 +338,7 @@ class TestConfig:
         [
             ("database", "postgres", "Invalid database"),
             ("testing", "pytest", "Invalid testing framework"),
+            ("e2e_testing", "espresso", "Invalid end-to-end testing framework"),
             ("auth_provider", "custom", "Invalid auth provider"),
             ("cloud_database", "supabase", "Invalid cloud database"),
             (

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -52,6 +52,7 @@ class TestConfigManager:
         assert "project" in config
         assert config["flutter"]["channel"] == "stable"
         assert config["project"]["org"] == "com.example"
+        assert config["project"]["e2e_testing"] == "integration_test"
 
     def test_create_default_config(self) -> None:
         """Test creating default config file."""

--- a/tests/test_e2e_create_append.py
+++ b/tests/test_e2e_create_append.py
@@ -331,6 +331,33 @@ class TestAppendSafeguards:
         config = mock_bs.call_args.args[0]
         assert config.org == "com.customorg"
 
+    def test_append_passes_patrol_e2e_option(self, tmp_path: Path) -> None:
+        """append passes the selected end-to-end framework into bootstrap."""
+        runner = CliRunner()
+        project_dir = tmp_path / "MyApp"
+        project_dir.mkdir()
+        (project_dir / "pubspec.yaml").write_text(
+            "name: my_app\nflutter:\n  uses-material-design: true\n"
+        )
+
+        with _patch_config(tmp_path):
+            with patch("flutter_setup.cli.ProjectBootstrap") as mock_bs:
+                mock_bs.return_value = MagicMock()
+                result = runner.invoke(
+                    cli,
+                    [
+                        "append",
+                        "--dir",
+                        str(project_dir),
+                        "--e2e-testing",
+                        "patrol",
+                    ],
+                )
+
+        assert result.exit_code == 0
+        config = mock_bs.call_args.args[0]
+        assert config.e2e_testing == "patrol"
+
 
 # ---------------------------------------------------------------------------
 # README safeguard (bootstrap level)

--- a/tests/test_e2e_fixtures.py
+++ b/tests/test_e2e_fixtures.py
@@ -21,6 +21,7 @@ from typing import Any, Iterator
 from unittest.mock import patch
 
 import pytest
+import yaml
 from click.testing import CliRunner
 
 from flutter_setup.bootstrap import ProjectBootstrap
@@ -116,8 +117,10 @@ class TestPhotoSlideshowAppend:
     at the responsible method.
     """
 
-    def _run(self, project_dir: Path, *, force: bool = False) -> None:
-        bootstrap = ProjectBootstrap(_make_config(project_dir), force=force)
+    def _run(self, project_dir: Path, *, force: bool = False, **overrides: Any) -> None:
+        bootstrap = ProjectBootstrap(
+            _make_config(project_dir, **overrides), force=force
+        )
         with _no_flutter_sdk():
             bootstrap.append_project()
 
@@ -169,6 +172,24 @@ class TestPhotoSlideshowAppend:
         self._run(photo_slideshow)
         readme = (photo_slideshow / "README.md").read_text()
         assert "## flutter-setup" in readme
+
+    def test_append_patrol_e2e_scaffold(self, photo_slideshow: Path) -> None:
+        self._run(photo_slideshow, e2e_testing="patrol")
+
+        patrol_test = photo_slideshow / "patrol_test" / "app_test.dart"
+        assert patrol_test.exists()
+        assert "patrolTest" in patrol_test.read_text()
+
+        pubspec = yaml.safe_load((photo_slideshow / "pubspec.yaml").read_text())
+        assert pubspec["dev_dependencies"]["patrol"] == "any"
+        assert (
+            pubspec["patrol"]["android"]["package_name"]
+            == "com.example.photo_slideshow"
+        )
+
+        makefile = (photo_slideshow / "Makefile").read_text()
+        assert "patrol-test:" in makefile
+        assert "patrol-doctor:" in makefile
 
     # --- existing files that must not be touched ----------------------------
 


### PR DESCRIPTION
## Summary

- Adds `--e2e-testing` CLI option to enable E2E test scaffolding in Flutter projects
- Supports both `patrol` and `integration_test` frameworks via a new `e2e_testing` config field
- Generates appropriate pubspec dependencies and test directory structure on bootstrap

## Changes

- `flutter_setup/cli.py`: new `--e2e-testing` flag with `patrol`/`integration_test` choices
- `flutter_setup/config.py`: `e2e_testing` field added to config schema
- `flutter_setup/config_manager.py`: wires e2e_testing through config management
- `flutter_setup/bootstrap.py`: generates patrol or integration_test scaffolding based on config
- `tests/`: full unit test coverage for all new paths

## Test plan

- [ ] Run `make test` and confirm all tests pass
- [ ] Verify `flutter-setup --e2e-testing patrol` generates patrol dependencies
- [ ] Verify `flutter-setup --e2e-testing integration_test` generates integration_test dependencies
- [ ] Confirm coverage remains ≥ 75%

🤖 Generated with [Claude Code](https://claude.com/claude-code)