### PR TITLE
feat: use pyenv to install Python and uv in deps and check-deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ deps:
 	@command -v git > /dev/null 2>&1 || (echo "ERROR: git not found. Install git and try again." && exit 1)
 	@echo "Installing Python $(PYTHON_VERSION) via pyenv..."
 	@pyenv install --skip-existing $(PYTHON_VERSION)
-	@pyenv local $(PYTHON_VERSION)
 	@echo "Installing uv for Python $(PYTHON_VERSION)..."
 	@pyenv exec pip install --quiet uv
 	@echo "OK: Python $(PYTHON_VERSION) and uv installed via pyenv"
@@ -33,7 +32,7 @@ deps:
 check-deps:
 	@command -v pyenv > /dev/null 2>&1 || (echo "ERROR: pyenv not found. Install from https://github.com/pyenv/pyenv#installation" && exit 1)
 	@command -v git > /dev/null 2>&1 || (echo "ERROR: git not found. Install git and try again." && exit 1)
-	@pyenv version-name 2>/dev/null | grep -q "$(PYTHON_VERSION)" \
+	@pyenv version-name 2>/dev/null | grep -qF "$(PYTHON_VERSION)" \
 		|| (echo "ERROR: pyenv is not set to Python $(PYTHON_VERSION). Run 'make deps' first." && exit 1)
 	@pyenv exec python -c "import sys; sys.exit(0) if sys.version_info >= (3, 12) else sys.exit('Python 3.12+ required, found ' + sys.version)" \
 		|| (echo "ERROR: Python 3.12+ required." && exit 1)

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
-.PHONY: help setup check-deps install dev test lint type-check format check-all clean smoke-build-fast smoke-build-full smoke-test-fast smoke-test-full
+.PHONY: help deps setup check-deps install dev test lint type-check format check-all clean smoke-build-fast smoke-build-full smoke-test-fast smoke-test-full
 
 help:
 	@echo "Available commands:"
-	@echo "  setup              - Set up the full dev environment (run this first)"
+	@echo "  deps               - Install Python via pyenv and uv (run once per machine)"
+	@echo "  setup              - Set up the full dev environment (run after deps)"
 	@echo "  check-deps         - Check that required tools are installed"
 	@echo "  install            - Install package (production)"
 	@echo "  dev                - Install package in development mode"
@@ -17,37 +18,53 @@ help:
 	@echo "  smoke-test-full    - Run full E2E smoke test (clean environment)"
 	@echo "  clean              - Remove build artifacts and caches"
 
-check-deps:
-	@command -v uv > /dev/null 2>&1 || (echo "ERROR: uv not found. Install from https://docs.astral.sh/uv/getting-started/installation/" && exit 1)
+PYTHON_VERSION := $(shell cat .python-version 2>/dev/null || echo "3.12")
+
+deps:
+	@command -v pyenv > /dev/null 2>&1 || (echo "ERROR: pyenv not found. Install from https://github.com/pyenv/pyenv#installation" && exit 1)
 	@command -v git > /dev/null 2>&1 || (echo "ERROR: git not found. Install git and try again." && exit 1)
-	@python3 -c "import sys; sys.exit(0) if sys.version_info >= (3, 12) else sys.exit('Python 3.12+ required, found ' + sys.version)" \
+	@echo "Installing Python $(PYTHON_VERSION) via pyenv..."
+	@pyenv install --skip-existing $(PYTHON_VERSION)
+	@pyenv local $(PYTHON_VERSION)
+	@echo "Installing uv for Python $(PYTHON_VERSION)..."
+	@pyenv exec pip install --quiet uv
+	@echo "OK: Python $(PYTHON_VERSION) and uv installed via pyenv"
+
+check-deps:
+	@command -v pyenv > /dev/null 2>&1 || (echo "ERROR: pyenv not found. Install from https://github.com/pyenv/pyenv#installation" && exit 1)
+	@command -v git > /dev/null 2>&1 || (echo "ERROR: git not found. Install git and try again." && exit 1)
+	@pyenv version-name 2>/dev/null | grep -q "$(PYTHON_VERSION)" \
+		|| (echo "ERROR: pyenv is not set to Python $(PYTHON_VERSION). Run 'make deps' first." && exit 1)
+	@pyenv exec python -c "import sys; sys.exit(0) if sys.version_info >= (3, 12) else sys.exit('Python 3.12+ required, found ' + sys.version)" \
 		|| (echo "ERROR: Python 3.12+ required." && exit 1)
-	@echo "OK: uv, git, and Python 3.12+ all present"
+	@pyenv exec python -m uv --version > /dev/null 2>&1 \
+		|| (echo "ERROR: uv not found. Run 'make deps' first." && exit 1)
+	@echo "OK: pyenv, Python $(PYTHON_VERSION), uv, and git all present"
 
 setup: check-deps
-	uv sync
-	uv pip install -e ".[dev]"
-	uv run pre-commit install
+	pyenv exec python -m uv sync
+	pyenv exec python -m uv pip install -e ".[dev]"
+	pyenv exec python -m uv run pre-commit install
 	@echo ""
 	@echo "Dev environment ready. Try 'make test' to verify."
 
 install:
-	uv pip install .
+	pyenv exec python -m uv pip install .
 
 dev:
-	uv pip install -e ".[dev]"
+	pyenv exec python -m uv pip install -e ".[dev]"
 
 test:
-	uv run pytest
+	pyenv exec python -m uv run pytest
 
 lint:
-	uv run ruff check .
+	pyenv exec python -m uv run ruff check .
 
 type-check:
-	uv run mypy .
+	pyenv exec python -m uv run mypy .
 
 format:
-	uv run black .
+	pyenv exec python -m uv run black .
 
 check-all: lint type-check test
 


### PR DESCRIPTION
## Summary

- Add a new `make deps` target that installs the correct Python version via pyenv (read from `.python-version`) and then installs `uv` into that interpreter
- Update `make check-deps` to verify the pyenv-managed Python and uv are present, replacing the old system `python3`/`uv` checks
- Update all `uv` invocations across `setup`, `install`, `dev`, `test`, `lint`, `type-check`, and `format` to use `pyenv exec python -m uv` for consistency

## Test plan

- [ ] Run `make deps` on a clean machine — confirms pyenv installs Python 3.12 and uv
- [ ] Run `make check-deps` after `make deps` — should report OK
- [ ] Run `make check-deps` without running `make deps` first — should fail with a clear error pointing to `make deps`
- [ ] Run `make setup` — confirms uv sync and pre-commit install still work
- [ ] Run `make test` — confirms tests pass through pyenv-managed uv

🤖 Generated with [Claude Code](https://claude.com/claude-code)